### PR TITLE
Consolidate job execution under fast successive DB writes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,5 @@
+name: 'pjobq'
+description: 'Dockerfile build'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/notes/considerations.md
+++ b/notes/considerations.md
@@ -1,19 +1,4 @@
 # Development concerns moving forward
+Until you can define job execution time more precisely, there will be issues with scheduling.
 
-## Road map
-- Pull apart bootstrap.py to be more testable
-- Tag a version, and cut a dev branch
-
-
-## Testing
-The bootstap module is difficult to unit test.
-TODO:
-Extract as much of the logic as possible to pure functions you can test.
-
-
-More performance tests need to be done in order to profile the system.
-
-TODO:
-Define a test that schedules adhoc jobs at a given time in the future and
-waits for the response, then repeats this after a wait period, using incrementing response payloads.
-Find the smallest wait interval that gives consistent responses.
+Specifically, if you write to the adhoc_jobs table multiple times within the error period for a job to execute, the job might get executed more than once.

--- a/notes/considerations.md
+++ b/notes/considerations.md
@@ -1,4 +1,2 @@
 # Development concerns moving forward
-Until you can define job execution time more precisely, there will be issues with scheduling.
-
-Specifically, if you write to the adhoc_jobs table multiple times within the error period for a job to execute, the job might get executed more than once.
+- Double execution seems to remain a problem even at write intervals of 0.1 seconds.

--- a/notes/scratch.py
+++ b/notes/scratch.py
@@ -37,3 +37,22 @@ async def run_test(n):
     await asyncio.gather(*[
         make_adhoc_job(1)
         for i in range(n)])
+
+
+async def main():
+    import time
+    t0 = time.time()
+    t1 = None
+    def cb():
+        nonlocal t1
+        t1 = time.time()
+        return
+    loop = asyncio.get_event_loop()
+    loop.call_later(0.1, cb)
+    await asyncio.sleep(1)
+    print(t1 - t0)
+    return
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/performance/main.py
+++ b/performance/main.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import asyncio
+import json
+import os
+import pprint
+import time
+from uuid import uuid4
+os.environ["PGPASSWORD"] = "performance-testing"
+
+from aiohttp import web
+
+from pjobq import get_models
+
+
+class TestResults:
+    def __init__(self):
+        self.res = {}
+
+    def set_received(self, res_id: str):
+        self.res[res_id]["received"].append(time.time())
+        return
+
+    def set_sent(self, req_id: str, sched_time: float):
+        self.res[req_id] = {
+            "requested": sched_time,
+            "received": [],
+        }
+        return
+
+
+async def start_test_http_server(test: TestResults):
+    async def base_handler(req):
+        body = await req.text()
+        test.set_received(body)
+        # req_q.put_nowait(body)
+        return web.Response(text="TEST-OK")
+    app = web.Application()
+    app.add_routes([web.post("/", base_handler)])
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '0.0.0.0', 9999)
+    print("starting test server...")
+    await site.start()
+    return
+
+
+async def make_adhoc_job(create_job, at: float, req_id: str):
+    await create_job(
+        schedule_ts=at,
+        job_name="test-job",
+        cmd_type="HTTP",
+        cmd_payload=json.dumps({"method": "POST", "url": "http://localhost:9999", "body": req_id}))
+    return
+
+
+async def test_many(n_tests: int, offset: float):
+    loop = asyncio.get_event_loop()
+    # req_q = asyncio.Queue()
+    test = TestResults()
+    adhoc, cron = await get_models()
+    server_task = loop.create_task(start_test_http_server(test))
+    await asyncio.sleep(2)
+    print("starting tests")
+    for i in range(n_tests):
+        req_id  = str(uuid4())
+        sched_time = time.time() + offset
+        test.set_sent(req_id, sched_time)
+        # print("req", req_id)
+        await make_adhoc_job(adhoc.create_job, sched_time, req_id)
+        # print("res", res)
+    print("tests complete")
+    await asyncio.sleep(5)      # let the server cool down
+    for trial, result in test.res.items():
+        if len(result["received"]) != 1:
+            print(trial, pprint.pformat(result))
+    return
+
+
+async def main():
+    import sys
+    n_tests = int(sys.argv[1])
+    offset = float(sys.argv[2])
+    await test_many(n_tests, offset)
+    return
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/performance/main.py
+++ b/performance/main.py
@@ -33,7 +33,7 @@ async def start_test_http_server(test: TestResults):
     async def base_handler(req):
         body = await req.text()
         test.set_received(body)
-        # req_q.put_nowait(body)
+        print("received", body)
         return web.Response(text="TEST-OK")
     app = web.Application()
     app.add_routes([web.post("/", base_handler)])

--- a/performance/tools/run_db.sh
+++ b/performance/tools/run_db.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 docker run -d --rm --net=host \
+       --name performance-test-db \
        -e POSTGRES_PASSWORD=performance-testing \
        postgres:12.2

--- a/performance/tools/run_db.sh
+++ b/performance/tools/run_db.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker run -d --rm --net=host \
+       -e POSTGRES_PASSWORD=performance-testing \
+       postgres:12.2

--- a/pjobq/logic/scheduling/adhoc.py
+++ b/pjobq/logic/scheduling/adhoc.py
@@ -40,6 +40,7 @@ def schedule_adhoc_jobs(
                 # nothing to reschedule
                 continue
             if job.job_id in scheduler.executing:
+                logging.info("can't reschedule job as it's already executing - %s", job.job_id)
                 # we can't cancel it, it's already executing.
                 # we just skip this job
                 continue

--- a/pjobq/logic/scheduling/adhoc.py
+++ b/pjobq/logic/scheduling/adhoc.py
@@ -40,7 +40,9 @@ def schedule_adhoc_jobs(
                 # nothing to reschedule
                 continue
             if job.job_id in scheduler.executing:
-                logging.info("can't reschedule job as it's already executing - %s", job.job_id)
+                logging.info(
+                    "can't reschedule job as it's already executing - %s", job.job_id
+                )
                 # we can't cancel it, it's already executing.
                 # we just skip this job
                 continue
@@ -49,7 +51,9 @@ def schedule_adhoc_jobs(
 
         scheduler.sched_time[job.job_id] = job.schedule_ts
         scheduler.scheduled[job.job_id] = schedule_execution(
-            loop, job_execution_cb_factory(scheduler, loop, job, handler), job.schedule_ts
+            loop,
+            job_execution_cb_factory(scheduler, loop, job, handler),
+            job.schedule_ts,
         )
     return
 
@@ -65,6 +69,7 @@ def job_execution_cb_factory(
     We run the job as an asyncio Task.
     Clean up the scheduler when the job has completed.
     """
+
     async def execute_job() -> None:
         await run_adhoc_job(scheduler.adhoc_job_model, handler, job)
         scheduler.sched_time.pop(job.job_id)

--- a/pjobq/models/adhoc_job/impl.py
+++ b/pjobq/models/adhoc_job/impl.py
@@ -26,6 +26,7 @@ class AdhocJobModelImpl(AdhocJobModel):
           FROM adhoc_job
          WHERE schedule_ts >= to_timestamp($1)
            AND schedule_ts <= to_timestamp($2)
+           AND completed_ts IS NULL
         """
         rows = await self.db.fetch(sql, [start_time, end_time])
         return [adhoc_job_converter(row) for row in rows]

--- a/pjobq/models/adhoc_job/impl.py
+++ b/pjobq/models/adhoc_job/impl.py
@@ -18,7 +18,7 @@ class AdhocJobModelImpl(AdhocJobModel):
         end_time: float,
     ) -> list[AdhocJob]:
         sql = """
-        SELECT job_id,
+        SELECT job_id::TEXT,
                job_name,
                EXTRACT(epoch FROM schedule_ts) schedule_ts,
                cmd_type,

--- a/pjobq/models/cron_job/impl.py
+++ b/pjobq/models/cron_job/impl.py
@@ -12,7 +12,7 @@ class CronJobModelImpl(CronJobModel):
 
     async def get_all(self) -> list[CronJob]:
         sql = """
-        SELECT job_id,
+        SELECT job_id::TEXT,
                job_name,
                cron_schedule,
                cmd_type,

--- a/pjobq/state/adhoc_scheduler.py
+++ b/pjobq/state/adhoc_scheduler.py
@@ -23,6 +23,7 @@ class AdhocSchedulerState:
     We refer to the current time range as the 'window'.
     """
 
+    sched_time: dict[str, float]
     scheduled: dict[str, TimerHandle]
     executing: dict[str, bool]
     adhoc_job_model: AdhocJobModel
@@ -33,6 +34,7 @@ class AdhocSchedulerState:
         self,
         adhoc_job_model: AdhocJobModel,
     ):
+        self.sched_time = {}
         self.scheduled = {}
         self.executing = {}
         self.adhoc_job_model = adhoc_job_model

--- a/pjobq/state/adhoc_scheduler.py
+++ b/pjobq/state/adhoc_scheduler.py
@@ -26,6 +26,13 @@ class AdhocSchedulerState:
     sched_time: dict[str, float]
     scheduled: dict[str, TimerHandle]
     executing: dict[str, bool]
+    # because we rely on the DB to keep track of
+    # completed jobs, if jobs are reloaded before
+    # we have a chance to mark them done in the DB,
+    # they can be executed twice.
+    # Thus keep a working copy of finished jobs.
+    finished_cooldown: dict[str, bool]
+
     adhoc_job_model: AdhocJobModel
     start_time: float = 0
     end_time: float = 0
@@ -37,5 +44,6 @@ class AdhocSchedulerState:
         self.sched_time = {}
         self.scheduled = {}
         self.executing = {}
+        self.finished_cooldown = {}
         self.adhoc_job_model = adhoc_job_model
         return self

--- a/pjobq/state/adhoc_scheduler.py
+++ b/pjobq/state/adhoc_scheduler.py
@@ -8,7 +8,7 @@ However, we must query the adhoc_jobs table at the same interval as our cache,
 so it cannot be arbitrarily small.
 """
 
-from asyncio import Task
+from asyncio import TimerHandle
 
 from pjobq.models import AdhocJobModel
 
@@ -23,7 +23,8 @@ class AdhocSchedulerState:
     We refer to the current time range as the 'window'.
     """
 
-    scheduled: dict[str, Task]
+    scheduled: dict[str, TimerHandle]
+    executing: dict[str, bool]
     adhoc_job_model: AdhocJobModel
     start_time: float = 0
     end_time: float = 0
@@ -33,5 +34,6 @@ class AdhocSchedulerState:
         adhoc_job_model: AdhocJobModel,
     ):
         self.scheduled = {}
+        self.executing = {}
         self.adhoc_job_model = adhoc_job_model
         return self

--- a/test/pjobq/util.test.py
+++ b/test/pjobq/util.test.py
@@ -32,14 +32,16 @@ class TestUtil(IsolatedAsyncioTestCase):
         return
 
 
-    async def test_delay_execution(self):
+    async def test_schedule_execution(self):
         mock = MagicMock()
-        async def test_fn():
+        def test_fn():
             mock(time.time())
         now = time.time()
         soon = now + 1
-        await util.delay_execution(test_fn(), soon)
-        self.assertAlmostEqual(mock.call_args_list[0].args[0], soon, 1) # we aren't very precise
+        loop = asyncio.get_event_loop()
+        util.schedule_execution(loop, test_fn, soon)
+        await asyncio.sleep(1)  # wait for it
+        self.assertAlmostEqual(mock.call_args_list[0].args[0], soon, 2)
         return
 
 


### PR DESCRIPTION
Use asyncio loop.call_later to handle execution - more precise than timeouts with asyncio.sleep.
Track completed jobs in memory to prevent double scheduling.